### PR TITLE
Duplicate #232 to #452

### DIFF
--- a/Tracks.txt
+++ b/Tracks.txt
@@ -339,3 +339,4 @@
 448 Indianapolis Motor Speedway - Road Course
 449 Motorsport Arena Oschersleben - Grand Prix
 451 Rudskogen Motorsenter
+452 Lucas Oil Raceway - Oval


### PR DESCRIPTION
Lucas Oil Raceway - Oval for 2022S4W4 Dirt Oval